### PR TITLE
Resolve "failed to read key" error

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -124,7 +124,7 @@ resource "aws_instance" "chef-server" {
   connection {
     host        = "${self.public_ip}"
     user        = "${lookup(var.ami_usermap, var.ami_os)}"
-    private_key = "${var.aws_private_key_file}"
+    private_key = "${file(var.aws_private_key_file)}"
   }
   # Setup
   provisioner "remote-exec" {


### PR DESCRIPTION
Running the current cookbook with tf 0.7.5 resulted in:

```
Error applying plan:

1 error(s) occurred:

* Failed to read key "C:/vandalay-ind.pem": no key found

Terraform does not automatically rollback in the face of errors.
Instead, your Terraform state file has been partially updated with
any resources that successfully completed. Please address the error
above and apply again to incrementally change your infrastructure.
```
